### PR TITLE
Typo: Update → Add as the verb used when adding new IDL files

### DIFF
--- a/wpt-sync/sync.js
+++ b/wpt-sync/sync.js
@@ -67,7 +67,7 @@ function createLocalBranches(srcDir, dstDir, makeCommitMessage) {
         } else {
             console.log(`  ${file} is added`);
             fs.writeFileSync(`${dstDir}/${file}`, reffyBytes);
-            commitToBranch('Update', file);
+            commitToBranch('Add', file);
         }
     }
 


### PR DESCRIPTION
This was copypasta, the whole point of the verb argument was to allow for this
distinction.

Fixes https://github.com/tidoust/reffy-reports/issues/22.