### PR TITLE
Change the user name for wpt IDL updates to just "autofoolip"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - git fetch -q fork
   - git push -q fork master
   - git config user.email "auto@foolip.org"
-  - git config user.name "Automat af Gränssnitt"
+  - git config user.name "autofoolip"
   - cd ..
 script:
   - GH_USER=autofoolip node sync.js --wpt-dir wpt --build-url https://travis-ci.org/tidoust/reffy-reports/builds/$TRAVIS_BUILD_ID


### PR DESCRIPTION
"Automat af Gränssnitt" was a funny name I gave it during development,
but better to name it in a way that makes it easier to find the GitHub
account creating the commits.