### PR TITLE
Add a package.json version (0.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "reffy-reports",
   "description": "Reports of Reffy crawls and analyses.",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tidoust/reffy-reports.git"


### PR DESCRIPTION
Without this, `npm install` on a repo depending on reffy-reports (as a
git reference) will fail because of "Missing package version."