### PR TITLE
Split updates of ED and TR reports

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -4,44 +4,44 @@ on:
   push:
     branches:
     - master
-name: update
+name: Update ED report
 jobs:
   update:
     runs-on: ubuntu-18.04
     steps:
-    - name: checkout
+    - name: Checkout reffy-reports
       uses: actions/checkout@master
-    - name: checkout reffy
+    - name: Checkout reffy
       uses: actions/checkout@master
       with:
         repository: tidoust/reffy
         ref: master
         fetch-depth: 1
         path: reffy
-    - name: setup node
+    - name: Setup node.js
       uses: actions/setup-node@master
       with:
         node-version: 10.x
-    - name: install pandoc
+    - name: Install pandoc
       run: sudo apt-get install pandoc
-    - name: setup reffy
+    - name: Setup Reffy
       run: |
         echo "${{ secrets.CONFIG_JSON }}" | base64 --decode > config.json
         npm ci
       working-directory: ../reffy
-    - name: reffy crawl
-      run: npm run all
+    - name: Run Reffy's crawler
+      run: npm run ed
       working-directory: ../reffy
-    - name: copy reports
+    - name: Copy reports
       run: rsync -av --exclude=README.md ../reffy/reports/ ./
-    - name: git push
+    - name: Push updates to git
       run: |
         git config user.name "reffy-bot"
         git config user.email "<>"
         git remote set-url --push origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git add -A
         REFFY_SHA=$(git --git-dir=../reffy/.git rev-parse HEAD)
-        git commit -m "Update from new reffy run" -m "Using reffy commit $REFFY_SHA."
+        git commit -m "Update of ED report from new reffy run" -m "Using reffy commit $REFFY_SHA."
         #npm version patch
         git push origin HEAD:master
         #git push origin --tags

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -1,0 +1,44 @@
+on:
+  schedule:
+    - cron: '11 11 * * 1'
+name: Update TR report
+jobs:
+  update:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout reffy-reports
+      uses: actions/checkout@master
+    - name: Checkout reffy
+      uses: actions/checkout@master
+      with:
+        repository: tidoust/reffy
+        ref: master
+        fetch-depth: 1
+        path: reffy
+    - name: Setup node.js
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.x
+    - name: Install pandoc
+      run: sudo apt-get install pandoc
+    - name: Setup Reffy
+      run: |
+        echo "${{ secrets.CONFIG_JSON }}" | base64 --decode > config.json
+        npm ci
+      working-directory: ../reffy
+    - name: Run Reffy's crawler
+      run: npm run tr
+      working-directory: ../reffy
+    - name: Copy reports
+      run: rsync -av --exclude=README.md ../reffy/reports/ ./
+    - name: Push updates to git
+      run: |
+        git config user.name "reffy-bot"
+        git config user.email "<>"
+        git remote set-url --push origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git add -A
+        REFFY_SHA=$(git --git-dir=../reffy/.git rev-parse HEAD)
+        git commit -m "Update of TR report from new reffy run" -m "Using reffy commit $REFFY_SHA."
+        #npm version patch
+        git push origin HEAD:master
+        #git push origin --tags


### PR DESCRIPTION
The TR report is secondary, no need to push an update 4 times a day. The update
splits the update workflow into two workflows: one for the ED report and one for
the TR report.

The ED crawl runs 4 times per day and after a push on master as before.
The TR crawl runs 1 time per week on Monday.

Also renamed action names to be a tad more explicit (and to start with an uppercase letter, coz' I like it more)